### PR TITLE
Include links to chrome:// URLs in plain text as GitHub seems to filter links to unknown URL schemes

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,10 +5,10 @@ Follow Link is a simple chrome extension for following links on any website with
 ## Installation
 
 1. Checkout this repo
-2. Open Chromes [extensions](chrome://extensions/)
+2. Open Chromes extensions: `chrome://extensions/`
 3. Enable `Developer mode`
 4. Press `Load unpacked extension...` and choose the location for the source code
-5. [Configure shortcuts](chrome://extensions/configureCommands)
+5. Configure shortcuts: `chrome://extensions/configureCommands`
 
 ## Usage
 


### PR DESCRIPTION
Just took me 10 minutes trying to figure out how to configure shortcuts because Github doesn't show the links to `chrome://` URLs...
